### PR TITLE
Allow ttyAMA and ttyS for RaspberryPi

### DIFF
--- a/vedirect_m8/serutils.py
+++ b/vedirect_m8/serutils.py
@@ -64,7 +64,7 @@ class SerialUtils (UType):
         """Test if is valid serial port name pattern."""
         return SerialUtils.is_str(data) and SerialUtils.is_list(
             re.compile(
-                r'^((?:tty(?:USB|ACM)|vmodem|COM)\d{1,3})$'
+                r'^((?:tty(?:USB|ACM|AMA|S)|vmodem|COM)\d{1,3})$'
             ).findall(data),
             not_null=True
         )
@@ -74,7 +74,7 @@ class SerialUtils (UType):
         """Test if is valid unix serial port pattern."""
         return SerialUtils.is_str(data) and SerialUtils.is_list(
             re.compile(
-                r'^(/dev/(tty(?:USB|ACM)\d{1,3}))$'
+                r'^(/dev/(tty(?:USB|ACM|AMA|S)\d{1,3}))$'
                 ).findall(data),
             not_null=True
         )


### PR DESCRIPTION
Added AMA an S to tests to allow ttyAMA0 and/or ttyS0 on RaspberryPi